### PR TITLE
Stabilize battle UI lifecycle: null checks, safe subscriptions, and stale-response handling

### DIFF
--- a/as3/src_flash/src/com/github/under/calculationelo/EloBattleDisplayable.as
+++ b/as3/src_flash/src/com/github/under/calculationelo/EloBattleDisplayable.as
@@ -16,6 +16,11 @@ package com.github.under.calculationelo
 
         public function initBattle():void
         {
+            if (this.battlePage == null || this.componentName == null || this.componentName.length == 0)
+            {
+                return;
+            }
+
             if (!this.battlePage.contains(this))
             {
                 this.battlePage.addChild(this);

--- a/as3/src_flash/src/com/github/under/calculationelo/EloPanelInjector.as
+++ b/as3/src_flash/src/com/github/under/calculationelo/EloPanelInjector.as
@@ -23,13 +23,21 @@ package com.github.under.calculationelo
         {
             super.onPopulate();
 
-            if (_activeComponent != null) return;
+            if (_activeComponent != null)
+            {
+                return;
+            }
 
             var mainViewContainer:MainViewContainer = MainViewContainer(
                 App.containerMgr.getContainer(
                     LAYER_NAMES.LAYER_ORDER.indexOf(LAYER_NAMES.VIEWS)
                 )
             );
+
+            if (mainViewContainer == null)
+            {
+                return;
+            }
 
             var view:BaseBattlePage = null;
             var idx:int = 0;
@@ -50,7 +58,11 @@ package com.github.under.calculationelo
                 _activeComponent = component;
             }
 
-            mainViewContainer.setFocusedView(mainViewContainer.getTopmostView());
+            var topView:ISimpleManagedContainer = mainViewContainer.getTopmostView();
+            if (topView != null)
+            {
+                mainViewContainer.setFocusedView(topView);
+            }
         }
 
         override protected function onDispose():void

--- a/python/gui/mods/CalculationElo/battle_provider.py
+++ b/python/gui/mods/CalculationElo/battle_provider.py
@@ -42,6 +42,7 @@ class BattleProvider(object):
         self._isBattleActive = False
         self._isStrongholdBattle = False
         self._battleSessionId = 0
+        self._fallbackSubscribed = False
 
         BattleProvider._instance = self
         self._installOverrides()
@@ -68,9 +69,6 @@ class BattleProvider(object):
                     inst._onAvatarBecomeNonPlayer()
                 baseMethod(baseObject, *a, **kw)
 
-            BattleProvider._hooked = True
-            logger.debug('[BattleProvider] PlayerAvatar overrides installed')
-
             @override(BattleReplay.BattleReplay, 'onReplayFinished')
             def hooked_onReplayFinished(baseMethod, baseObject, *a, **kw):
                 inst = BattleProvider._instance
@@ -78,6 +76,8 @@ class BattleProvider(object):
                     inst._onAvatarBecomeNonPlayer()
                 return baseMethod(baseObject, *a, **kw)
 
+            BattleProvider._hooked = True
+            logger.debug('[BattleProvider] PlayerAvatar/BattleReplay overrides installed')
             logger.debug('[BattleProvider] BattleReplay override installed')
 
         except Exception as e:
@@ -91,6 +91,7 @@ class BattleProvider(object):
             from PlayerEvents import g_playerEvents
             g_playerEvents.onAvatarReady += self._onAvatarReady
             g_playerEvents.onAvatarBecomeNonPlayer += self._onAvatarBecomeNonPlayer
+            self._fallbackSubscribed = True
             logger.debug('[BattleProvider] Fallback: using g_playerEvents')
         except Exception as e:
             logger.error('[BattleProvider] Fallback subscription also failed: %s', e)
@@ -101,11 +102,12 @@ class BattleProvider(object):
         if BattleProvider._instance is self:
             BattleProvider._instance = None
 
-        if not BattleProvider._hooked:
+        if self._fallbackSubscribed:
             try:
                 from PlayerEvents import g_playerEvents
                 g_playerEvents.onAvatarReady -= self._onAvatarReady
                 g_playerEvents.onAvatarBecomeNonPlayer -= self._onAvatarBecomeNonPlayer
+                self._fallbackSubscribed = False
             except Exception as e:
                 logger.error('[BattleProvider] Error in fini: %s', e)
 

--- a/python/gui/mods/CalculationElo/battle_state_events.py
+++ b/python/gui/mods/CalculationElo/battle_state_events.py
@@ -26,6 +26,7 @@ class BattleStateEvents(object):
         self._hiddenByStatsPopup = False
         self._hiddenByKillCam = False
         self._interfaceScale = 1.0
+        self._killCamCtrl = None
 
         self.onBattleLoaded = Event.SafeEvent()
         self.onBattleClosed = Event.SafeEvent()
@@ -90,6 +91,7 @@ class BattleStateEvents(object):
     def _onGUISpaceLeft(self, spaceID):
         from skeletons.gui.app_loader import GuiGlobalSpaceID
         if spaceID == GuiGlobalSpaceID.BATTLE:
+            self._unsubscribeKillCam()
             self.onBattleClosed()
 
     def _onGUIVisibility(self, event):
@@ -118,12 +120,27 @@ class BattleStateEvents(object):
             settingsCore = dependency.instance(ISettingsCore)
             self._interfaceScale = round(settingsCore.interfaceScale.get(), 1)
 
+            self._unsubscribeKillCam()
+
             sessionProvider = dependency.instance(IBattleSessionProvider)
             killCamCtrl = getattr(sessionProvider.shared, 'killCamCtrl', None)
             if killCamCtrl:
+                self._killCamCtrl = killCamCtrl
                 killCamCtrl.onKillCamModeStateChanged += self._onKillCamStateChanged
         except Exception as e:
             logger.debug('[BattleStateEvents] _handleBattleLoad fallback: %s', e)
+
+
+    def _unsubscribeKillCam(self):
+        if not self._killCamCtrl:
+            return
+
+        try:
+            self._killCamCtrl.onKillCamModeStateChanged -= self._onKillCamStateChanged
+        except Exception:
+            pass
+
+        self._killCamCtrl = None
 
     def _onKillCamStateChanged(self, state, *args, **kwargs):
         try:

--- a/python/gui/mods/CalculationElo/clan/clan_state_manager.py
+++ b/python/gui/mods/CalculationElo/clan/clan_state_manager.py
@@ -98,6 +98,7 @@ class ClanStateManager(object):
     def _onClanIdReceived(self, team, clanTag, clanId, sessionId):
         try:
             if sessionId != self._battleSessionId:
+                self._pendingRequests['{}_clan_id'.format(team)] = False
                 logger.debug('[ClanStateManager] Stale clan ID response for "%s" (session %s != %s), ignoring',
                              clanTag, sessionId, self._battleSessionId)
                 return
@@ -137,6 +138,7 @@ class ClanStateManager(object):
     def _onStrongholdInfoReceived(self, team, clanId, battleLevel, result, sessionId):
         try:
             if sessionId != self._battleSessionId:
+                self._pendingRequests['{}_info'.format(team)] = False
                 logger.debug('[ClanStateManager] Stale stronghold response for %s (session %s != %s), ignoring',
                              team, sessionId, self._battleSessionId)
                 return


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when UI components are initialized without a valid `battlePage` or `componentName`. 
- Avoid null dereferences and unsafe focus changes when the main view container or top view are not available. 
- Ensure event subscription fallbacks and kill-cam handlers are tracked and unsubscribed cleanly and mark stale async responses as completed.

### Description

- Add guard in `EloBattleDisplayable.initBattle` to return early if `battlePage` or `componentName` are null/empty. 
- In `EloPanelInjector.onPopulate` add null checks for the `mainViewContainer`, return early if already active, and only call `setFocusedView` when `getTopmostView()` returns a non-null `ISimpleManagedContainer`. 
- In `BattleProvider` add `_fallbackSubscribed` flag, set it when subscribing to `g_playerEvents` in `_installEventFallback`, and change `fini` to only attempt fallback unsubscription when the fallback was actually subscribed, clearing the flag afterward. 
- In `BattleStateEvents` add `_killCamCtrl` tracking, unsubscribe existing kill-cam handler before subscribing in `_handleBattleLoad`, and implement `_unsubscribeKillCam` to remove the handler and clear the reference on GUI leave. 
- In `ClanStateManager` mark pending request flags as `False` when asynchronous clan ID or stronghold info responses are ignored as stale to avoid leaving requests perpetually pending.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b87bafe14483238498d4990622bd94)